### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/dapicester/gitlab-ci-monitor.png?label=ready&title=Ready)](https://waffle.io/dapicester/gitlab-ci-monitor?utm_source=badge)
 # GitLab CI Monitor
 
 Monitor the latest build status with colored LEDs using an Arduino board


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/dapicester/gitlab-ci-monitor

This was requested by a real person (user dapicester) on waffle.io, we're not trying to spam you.